### PR TITLE
mobile title size reduced

### DIFF
--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -117,6 +117,11 @@
 }
 
 @media (max-width: 600px) {
+    .title {
+        margin: 0;
+        line-height: 1.15;
+        font-size: 2.2rem;
+    }
   .grid {
     width: 100%;
     flex-direction: column;


### PR DESCRIPTION
Hi @AnkitaMalik22 

Description:

Mobile title font size reduced to 2 rem

Closes issue: #24 

Screenshot:
![image](https://user-images.githubusercontent.com/42484705/195388851-978ac18d-abb4-4441-b0b4-ff46e0abe07f.png)
